### PR TITLE
Added `withSubmissionIdFullResponse` to make entire job status available to the user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ This project is provides a Fluent utility Http client to interact with Spark Sta
 "com.github.ywilkof" % "spark-jobs-rest-client" % "1.3.1"
 ```
 
-
 # Requirements
 - JAVA 1.8
 - Spark version supplying the Rest API. This client is compatabile with version 1.5 and above. 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This project is provides a Fluent utility Http client to interact with Spark Sta
 </dependency>
 ```
 
+# SBT
+```
+"com.github.ywilkof" % "spark-jobs-rest-client" % "1.3.1"
+```
+
+
 # Requirements
 - JAVA 1.8
 - Spark version supplying the Rest API. This client is compatabile with version 1.5 and above. 
@@ -27,7 +33,7 @@ In order to issue requests to a Spark cluster, a client has to be created.
 The client has several configurations, which will be used across all the requests issued from it.
 Master host and Spark Version are required and the rest of the fields have sensible defaults.
 
-```` java
+``` java
 SparkRestClient.builder()
     .masterHost("localhost")
     .sparkVersion("1.5.0")
@@ -80,6 +86,18 @@ Following is a basic job status request:
 final DriverState driverState = sparkRestClient
     .checkJobStatus()
     .withSubmissionId(submissionId);
+```
+
+If the location of the driver running is of interest, use `withSubmissionIdFullResponse`
+which includes the ip and port of the worker executing the driver:
+
+``` java 
+JobStatusResponse jobStatus = 
+   sparkRestClient
+    .checkJobStatus()
+    .withSubmissionIdFullResponse(submissionId);
+    
+ System.out.println(jobStatus.workerHostPort);
 ```
 
 ## Killing A Job

--- a/src/main/java/com/github/ywilkof/sparkrestclient/HttpRequestUtil.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/HttpRequestUtil.java
@@ -1,7 +1,5 @@
 package com.github.ywilkof.sparkrestclient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -15,12 +13,10 @@ public class HttpRequestUtil {
         try {
             final String stringResponse = client.execute(httpRequest, new BasicResponseHandler());
             if (stringResponse != null) {
-                response = (T) MapperWrapper.MAPPER.readValue(stringResponse, responseClass);
+                response = MapperWrapper.MAPPER.readValue(stringResponse, responseClass);
             } else {
                 throw new FailedSparkRequestException("Received empty string response");
             }
-        } catch (InvalidFormatException e) {
-            throw new FailedSparkRequestException(e);
         } catch (IOException e) {
             throw new FailedSparkRequestException(e);
         } finally {

--- a/src/main/java/com/github/ywilkof/sparkrestclient/JobStatusRequestSpecificationImpl.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/JobStatusRequestSpecificationImpl.java
@@ -21,13 +21,26 @@ public class JobStatusRequestSpecificationImpl implements JobStatusRequestSpecif
      */
     @Override
     public DriverState withSubmissionId(String submissionId) throws FailedSparkRequestException  {
+        JobStatusResponse response = withSubmissionIdFullResponse(submissionId);
+        return response.getDriverState();
+    }
+
+    /**
+     * Gets the status of an existing Driver Application.
+     * @param submissionId Id of submitted job to request status for.
+     * @return Full state of the application, including information on the location
+     * of the driver.
+     * @throws FailedSparkRequestException Request to Spark server failed,
+     * or the Spark Server could not retrieve the status of the requested app.
+     */
+    @Override
+    public JobStatusResponse withSubmissionIdFullResponse(String submissionId) throws FailedSparkRequestException {
         assertSubmissionId(submissionId);
         final String url = "http://" + sparkRestClient.getMasterUrl() + "/v1/submissions/status/" + submissionId;
         final JobStatusResponse response = HttpRequestUtil.executeHttpMethodAndGetResponse(sparkRestClient.getClient(), new HttpGet(url),JobStatusResponse.class);
         if (!response.getSuccess()) {
             throw new FailedSparkRequestException("submit was not successful.");
         }
-        return response.getDriverState();
+        return response;
     }
-
 }

--- a/src/main/java/com/github/ywilkof/sparkrestclient/JobStatusResponse.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/JobStatusResponse.java
@@ -1,19 +1,28 @@
 package com.github.ywilkof.sparkrestclient;
 
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
- * Created by yonatan on 08.10.15.
+ * Created by Yuval.Itzchakov on 30/01/2017.
  */
 @Getter
-class JobStatusResponse extends SparkResponse {
+@Setter(AccessLevel.PACKAGE)
+public class JobStatusResponse extends SparkResponse {
 
-    JobStatusResponse() {}
-
-    private DriverState driverState;
-
+    /**
+     * The address of worker which was assigned the driver process.
+     * Format: "[worker-ip]:[worker-port]"
+     */
     private String workerHostPort;
-
+    /**
+     * The worker ID as assigned by Spark.
+     */
     private String workerId;
 
+    /**
+     * Reports the status of the driver.
+     */
+    private DriverState driverState;
 }

--- a/src/main/java/com/github/ywilkof/sparkrestclient/JobSubmitRequestSpecificationImpl.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/JobSubmitRequestSpecificationImpl.java
@@ -36,7 +36,7 @@ public class JobSubmitRequestSpecificationImpl implements JobSubmitRequestSpecif
 
     private SparkRestClient sparkRestClient;
 
-    private Map<String,String> props = new HashMap<>();
+    private Map<String, String> props = new HashMap<>();
 
     public JobSubmitRequestSpecificationImpl(SparkRestClient sparkRestClient) {
         this.sparkRestClient = sparkRestClient;
@@ -101,7 +101,7 @@ public class JobSubmitRequestSpecificationImpl implements JobSubmitRequestSpecif
 
         @Override
         public SparkPropertiesSpecification put(String sparkProperty, String value) {
-            props.put(sparkProperty,value);
+            props.put(sparkProperty, value);
             return this;
         }
 
@@ -118,7 +118,7 @@ public class JobSubmitRequestSpecificationImpl implements JobSubmitRequestSpecif
      * @throws FailedSparkRequestException iff submission failed.
      */
     public String submit() throws FailedSparkRequestException {
-        if (mainClass == null || appResource  == null) {
+        if (mainClass == null || appResource == null) {
             throw new IllegalArgumentException("mainClass and appResource values must not be null");
         }
 
@@ -126,7 +126,7 @@ public class JobSubmitRequestSpecificationImpl implements JobSubmitRequestSpecif
                 .action(Action.CreateSubmissionRequest)
                 .appArgs((appArgs == null) ? Collections.emptyList() : appArgs)
                 .appResource(appResource)
-                .clientSparkVersion(sparkRestClient.getSparkVersion().toString())
+                .clientSparkVersion(sparkRestClient.getSparkVersion())
                 .mainClass(mainClass)
                 .environmentVariables(sparkRestClient.getEnvironmentVariables())
                 .sparkProperties(
@@ -158,8 +158,6 @@ public class JobSubmitRequestSpecificationImpl implements JobSubmitRequestSpecif
         }
         return response.getSubmissionId();
     }
-
-
 
     String jars(final String appResource, final Set<String> jars) {
         final Set<String> output = Stream.of(appResource).collect(Collectors.toSet());

--- a/src/main/java/com/github/ywilkof/sparkrestclient/SparkResponse.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/SparkResponse.java
@@ -1,24 +1,38 @@
 package com.github.ywilkof.sparkrestclient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Created by yonatan on 08.10.15.
  */
 @Getter
+@Setter(AccessLevel.PACKAGE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 class SparkResponse {
-
     SparkResponse() {}
 
     private Action action;
 
-    protected String message;
+    /**
+     * Message status.
+     */
+    private String message;
 
-    protected String serverSparkVersion;
+    /**
+     * Spark version.
+     */
+    private String serverSparkVersion;
 
-    protected String submissionId;
+    /**
+     * The submission ID as assigned by Spark.
+     */
+    private String submissionId;
 
-    protected Boolean success;
+    /**
+     * Marks the success or failure of the submission.
+     */
+    private Boolean success;
 }

--- a/src/main/java/com/github/ywilkof/sparkrestclient/interfaces/JobStatusRequestSpecification.java
+++ b/src/main/java/com/github/ywilkof/sparkrestclient/interfaces/JobStatusRequestSpecification.java
@@ -2,10 +2,12 @@ package com.github.ywilkof.sparkrestclient.interfaces;
 
 import com.github.ywilkof.sparkrestclient.DriverState;
 import com.github.ywilkof.sparkrestclient.FailedSparkRequestException;
+import com.github.ywilkof.sparkrestclient.JobStatusResponse;
 
 /**
  * Created by yonatan on 17.10.15.
  */
 public interface JobStatusRequestSpecification {
-    DriverState withSubmissionId(String submissionId)  throws FailedSparkRequestException;
+    DriverState withSubmissionId(String submissionId) throws FailedSparkRequestException;
+    JobStatusResponse withSubmissionIdFullResponse(String submissionId) throws FailedSparkRequestException;
 }


### PR DESCRIPTION
This pull request adds support for retrieving the entire `JobResponseStatus` object which includes information on the worker in which the driver is running (and "fixes" #9). This enables users to further be able to query the driver REST API (available at port 4040 on the driver) to see their application status in more depth.

This commit adds:

1. An additional method `withSubmissionIdFullResponse` to `JobStatusRequestSpecification`
2. Implementation of both `withSubmissionId` and the new API is shared, where the latter extracts the `DriverState`.
3. Added a test which validates the parsing of the job status is correct.
4. Minor spacing changes added (hope that's ok).
5. Added documentation to READ.me.