### PR TITLE
master port is optional for master url

### DIFF
--- a/src/test/java/com/github/ywilkof/sparkrestclient/SparkRestClientBuilderTest.java
+++ b/src/test/java/com/github/ywilkof/sparkrestclient/SparkRestClientBuilderTest.java
@@ -19,6 +19,15 @@ public class SparkRestClientBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void testBuild_WhenHostNotSet_ThenThrowException() throws Exception {
         builder.masterPort(6066);
+        builder.sparkVersion("2.1");
+        builder.build();
+    }
+
+    @Test
+    public void testBuild_WhenPortNotSet_ThenDontThrowException() throws Exception {
+        builder.masterPort(null);
+        builder.masterHost("somehost");
+        builder.sparkVersion("2.1");
         builder.build();
     }
 

--- a/src/test/java/com/github/ywilkof/sparkrestclient/SparkRestClientTest.java
+++ b/src/test/java/com/github/ywilkof/sparkrestclient/SparkRestClientTest.java
@@ -1,0 +1,57 @@
+package com.github.ywilkof.sparkrestclient;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SparkRestClientTest {
+
+    @Test
+    public void getMasterUrl_WhenMasterApiRootAndPortGiven_ThenProduceCorrectUrl() throws Exception {
+
+        final SparkRestClient subject = new SparkRestClient();
+        subject.setMasterApiRoot("root");
+        subject.setMasterPort(6066);
+        subject.setMasterHost("host");
+        Assert.assertEquals("host:6066/root", subject.getMasterUrl());
+    }
+
+    @Test
+    public void getMasterUrl_WhenMasterApiRootNotGivenAndPortGiven_ThenProduceCorrectUrl() throws Exception {
+
+        final SparkRestClient subject = new SparkRestClient();
+        subject.setMasterPort(6066);
+        subject.setMasterHost("host");
+        Assert.assertEquals("host:6066", subject.getMasterUrl());
+
+    }
+
+    @Test
+    public void getMasterUrl_WhenMasterApiRootGivenAndPortNNotGiven_ThenProduceCorrectUrl() throws Exception {
+
+        final SparkRestClient subject = new SparkRestClient();
+        subject.setMasterApiRoot("root");
+        subject.setMasterHost("host");
+        Assert.assertEquals("host/root", subject.getMasterUrl());
+
+    }
+
+    @Test
+    public void getMasterUrl_WhenMasterApiRootNotGivenAndPortNNotGiven_ThenProduceCorrectUrl() throws Exception {
+
+        final SparkRestClient subject = new SparkRestClient();
+        subject.setMasterHost("host");
+        Assert.assertEquals("host", subject.getMasterUrl());
+
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void getMasterUrl_WhenMasterHost_ThenThrowException() throws Exception {
+
+        final SparkRestClient subject = new SparkRestClient();
+        subject.getMasterUrl();
+
+    }
+
+}


### PR DESCRIPTION
port is now optional, and must not necessarily be supplied  for the curl command and in the spark.master property of the request body. 